### PR TITLE
Added a basic initializer which sets options to 0.

### DIFF
--- a/TCMXML/TCMXMLTests.m
+++ b/TCMXML/TCMXMLTests.m
@@ -63,4 +63,11 @@
 	STAssertEqualObjects(writer.XMLString,@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>" , @"Instruct failed");
 }
 
+- (void)testBasicInitializer {
+	TCMXMLWriter *writer = [[TCMXMLWriter alloc] init];
+	[writer instructXML];
+	[writer tag:@"theTag" contentText:@"theContent"];
+	STAssertEqualObjects(writer.XMLString,@"<?xml version=\"1.0\" encoding=\"UTF-8\"?><theTag>theContent</theTag>" , @"Instruct failed");
+}
+
 @end

--- a/TCMXML/TCMXMLWriter.m
+++ b/TCMXML/TCMXMLWriter.m
@@ -40,6 +40,10 @@
 
 @synthesize fileURL = _fileURL;
 
+- (id)init {
+    return [self initWithOptions:0];
+}
+
 - (id)initWithOptions:(TCMXMLWriterOptions)anOptionField {
 	if ((self = [super init])) {
 		_elementNameStackArray = [NSMutableArray new];


### PR DESCRIPTION
If we don't set the options to 0, the writer does not get initialized correctly.
In particular, in the test I added, the result will show up a

```
<?xml version=\"1.0\" encoding=\"UTF-8\"?><theTag>theContent</>
```

Note the `</>` where we would expect `</theTag>`.
